### PR TITLE
release: 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## [2.0.0](https://github.com/flex-development/aggregate-error-ponyfill/compare/2.0.0-alpha.4...2.0.0) (2022-09-30)
+
+
+### :package: Build
+
+* require at least node.js 14 ([7ad7469](https://github.com/flex-development/aggregate-error-ponyfill/commit/7ad74691b797efcf5fa5c5f25c43da7be2617e56))
+* set `typesVersions` ([745b3bf](https://github.com/flex-development/aggregate-error-ponyfill/commit/745b3bf5f21f8041519cf3d8cbca7bd2728737ba))
+* use `mkbuild` to build project ([36ef910](https://github.com/flex-development/aggregate-error-ponyfill/commit/36ef9103042358ff8714c49e66dc49e2c167348e))
+
+
+### :robot: Continuous Integration
+
+* **deps:** bump actions/github-script from 6.2.0 to 6.3.0 ([#6](https://github.com/flex-development/aggregate-error-ponyfill/issues/6)) ([ad85177](https://github.com/flex-development/aggregate-error-ponyfill/commit/ad85177ab87e51afbe6148863d7e4fb759670518))
+* **deps:** bump flex-development/dist-tag-action from 1.1.0 to 1.1.1 ([#8](https://github.com/flex-development/aggregate-error-ponyfill/issues/8)) ([c095a89](https://github.com/flex-development/aggregate-error-ponyfill/commit/c095a89a8aa7d0f5ab90e583c692b0ddf446d451))
+
+
+### :pencil: Documentation
+
+* built with ([bc1399f](https://github.com/flex-development/aggregate-error-ponyfill/commit/bc1399fe8436c93e11a96dd5e3762628610fde2d))
+
+
+### :house_with_garden: Housekeeping
+
+* cleanup ([5aea1d5](https://github.com/flex-development/aggregate-error-ponyfill/commit/5aea1d52da7cade5e9441f9e880dd9f68a5ad0e6))
+
 ## [2.0.0-alpha.4](https://github.com/flex-development/aggregate-error-ponyfill/compare/2.0.0-alpha.3...2.0.0-alpha.4) (2022-08-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/aggregate-error-ponyfill",
   "description": "ES Proposal spec-compliant ponyfill for AggregateError",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0",
   "keywords": [
     "aggregate-error",
     "es-proposal",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `2.0.0`
- added `CHANGELOG` entry for `2.0.0`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.23.4
      Coverage enabled with c8

 ✓ src/__tests__/ponyfill.spec.ts > unit:ponyfill > should create spec-compliant AggregateError
 ✓ src/__tests__/ponyfill.spec.ts > unit:ponyfill > should throw if aggregated errors are not iterable

Test Files  1 passed (1)
     Tests  2 passed (2)
  Start at  00:02:44
  Duration  3.80s (transform 545ms, setup 259ms, collect 119ms, tests 7ms)

 % Coverage report from c8
-------------|---------|----------|---------|---------|-------------------
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------|---------|----------|---------|---------|-------------------
All files    |     100 |      100 |     100 |     100 |                   
 ponyfill.ts |     100 |      100 |     100 |     100 |                   
-------------|---------|----------|---------|---------|-------------------
```

### `yarn pack -o %s-%v.tgz`

```zsh
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT ℹ Building @flex-development/aggregate-error-ponyfill
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT ✔ Build succeeded for @flex-development/aggregate-error-ponyfill
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   dist (total size: 3.44 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.mjs.map (115 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.mjs (59 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.d.mts (111 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.mjs.map (118 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.mjs (43 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.d.mts (115 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.mjs.map (846 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.mjs (742 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.d.mts (1.29 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   dist (total size: 5.5 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.cjs.map (210 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.cjs (649 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.d.cts (111 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.cjs.map (221 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.cjs (484 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.d.cts (115 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.cjs.map (1.02 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.cjs (1.41 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.d.cts (1.29 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT Σ Total build size: 8.94 kB
➤ YN0000: CHANGELOG.md
➤ YN0000: LICENSE.md
➤ YN0000: README.md
➤ YN0000: changelog.config.cts
➤ YN0000: dist/index.cjs
➤ YN0000: dist/index.cjs.map
➤ YN0000: dist/index.d.cts
➤ YN0000: dist/index.d.mts
➤ YN0000: dist/index.mjs
➤ YN0000: dist/index.mjs.map
➤ YN0000: dist/native.cjs
➤ YN0000: dist/native.cjs.map
➤ YN0000: dist/native.d.cts
➤ YN0000: dist/native.d.mts
➤ YN0000: dist/native.mjs
➤ YN0000: dist/native.mjs.map
➤ YN0000: dist/ponyfill.cjs
➤ YN0000: dist/ponyfill.cjs.map
➤ YN0000: dist/ponyfill.d.cts
➤ YN0000: dist/ponyfill.d.mts
➤ YN0000: dist/ponyfill.mjs
➤ YN0000: dist/ponyfill.mjs.map
➤ YN0000: package.json
➤ YN0000: src/index.ts
➤ YN0000: src/native.ts
➤ YN0000: src/ponyfill.ts
➤ YN0036: Calling the "postpack" lifecycle script
➤ YN0000: Package archive generated in ./@flex-development-aggregate-error-ponyfill-2.0.0.tgz
➤ YN0000: Done in 5s 770ms
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/aggregate-error-ponyfill/blob/main/CONTRIBUTING.md#pull-request-titles
