### PR TITLE
release: 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [2.0.1](https://github.com/flex-development/aggregate-error-ponyfill/compare/2.0.0...2.0.1) (2022-10-02)
+
+
+### :package: Build
+
+* **deps-dev:** bump @flex-development/mkbuild from 1.0.0-alpha.3 to 1.0.0-alpha.6 ([e8f11bb](https://github.com/flex-development/aggregate-error-ponyfill/commit/e8f11bb1325a656e660bfb7aa09bd084f3b52705))
+
+
+### :robot: Continuous Integration
+
+* **deps:** bump dependabot/fetch-metadata from 1.3.3 to 1.3.4 ([#11](https://github.com/flex-development/aggregate-error-ponyfill/issues/11)) ([9cf4fac](https://github.com/flex-development/aggregate-error-ponyfill/commit/9cf4fac3a0bd3f5ea0101f3a4125282e19b20f53))
+
+
+### :bug: Fixes
+
+* missing `default` exports ([#12](https://github.com/flex-development/aggregate-error-ponyfill/issues/12)) ([0f3239b](https://github.com/flex-development/aggregate-error-ponyfill/commit/0f3239b2fbbd14199800880058413d1567bb7716))
+
+
+### :house_with_garden: Housekeeping
+
+* **github:** add label `status:triaged` ([04fa1d3](https://github.com/flex-development/aggregate-error-ponyfill/commit/04fa1d34e4e67f8c2cfb56f6a86b20a937ee8cb3))
+
 ## [2.0.0](https://github.com/flex-development/aggregate-error-ponyfill/compare/2.0.0-alpha.4...2.0.0) (2022-09-30)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/aggregate-error-ponyfill",
   "description": "ES Proposal spec-compliant ponyfill for AggregateError",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "aggregate-error",
     "es-proposal",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `2.0.1`
- added `CHANGELOG` entry for `2.0.1`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.23.4
      Coverage enabled with c8

 ✓ src/__tests__/ponyfill.spec.ts > unit:ponyfill > should create spec-compliant AggregateError
 ✓ src/__tests__/ponyfill.spec.ts > unit:ponyfill > should throw if aggregated errors are not iterable

Test Files  1 passed (1)
     Tests  2 passed (2)
  Start at  02:15:56
  Duration  4.45s (transform 599ms, setup 296ms, collect 138ms, tests 7ms)

 % Coverage report from c8
-------------|---------|----------|---------|---------|-------------------
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------|---------|----------|---------|---------|-------------------
All files    |     100 |      100 |     100 |     100 |                   
 ponyfill.ts |     100 |      100 |     100 |     100 |                   
-------------|---------|----------|---------|---------|-------------------
```

### `yarn pack -o %s-%v.tgz`

```zsh
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT ℹ Building @flex-development/aggregate-error-ponyfill
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT ✔ Build succeeded for @flex-development/aggregate-error-ponyfill
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   dist (total size: 3.44 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.mjs.map (115 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.mjs (59 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.d.mts (111 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.mjs.map (118 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.mjs (43 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.d.mts (115 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.mjs.map (846 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.mjs (742 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.d.mts (1.29 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   dist (total size: 5.48 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.cjs.map (210 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.cjs (647 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.d.cts (111 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.cjs.map (221 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.cjs (484 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/native.d.cts (115 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.cjs.map (1.02 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.cjs (1.39 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.d.cts (1.29 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT Σ Total build size: 8.92 kB
➤ YN0000: CHANGELOG.md
➤ YN0000: LICENSE.md
➤ YN0000: README.md
➤ YN0000: changelog.config.cts
➤ YN0000: dist/index.cjs
➤ YN0000: dist/index.cjs.map
➤ YN0000: dist/index.d.cts
➤ YN0000: dist/index.d.mts
➤ YN0000: dist/index.mjs
➤ YN0000: dist/index.mjs.map
➤ YN0000: dist/native.cjs
➤ YN0000: dist/native.cjs.map
➤ YN0000: dist/native.d.cts
➤ YN0000: dist/native.d.mts
➤ YN0000: dist/native.mjs
➤ YN0000: dist/native.mjs.map
➤ YN0000: dist/ponyfill.cjs
➤ YN0000: dist/ponyfill.cjs.map
➤ YN0000: dist/ponyfill.d.cts
➤ YN0000: dist/ponyfill.d.mts
➤ YN0000: dist/ponyfill.mjs
➤ YN0000: dist/ponyfill.mjs.map
➤ YN0000: package.json
➤ YN0000: src/index.ts
➤ YN0000: src/native.ts
➤ YN0000: src/ponyfill.ts
➤ YN0036: Calling the "postpack" lifecycle script
➤ YN0000: Package archive generated in ./@flex-development-aggregate-error-ponyfill-2.0.1.tgz
➤ YN0000: Done in 6s 708ms
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

- releases #12 

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/aggregate-error-ponyfill/blob/main/CONTRIBUTING.md#pull-request-titles
