### PR TITLE
release: 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## [3.0.0](https://github.com/flex-development/aggregate-error-ponyfill/compare/2.0.1...3.0.0) (2022-11-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* remove `native` module
+
+### :package: Build
+
+* require node `>=14.16` ([abc02cf](https://github.com/flex-development/aggregate-error-ponyfill/commit/abc02cfa8d62b213428b95f07520139304dcfdef))
+* **deps:** bump es-abstract from 1.19.1 to 1.20.4 ([49d606f](https://github.com/flex-development/aggregate-error-ponyfill/commit/49d606fb2632f3eaea572d5050cd264ec0e9f67b))
+
+
+### :robot: Continuous Integration
+
+* **deps:** bump actions/checkout from 3.0.2 to 3.1.0 ([#14](https://github.com/flex-development/aggregate-error-ponyfill/issues/14)) ([ab7cde6](https://github.com/flex-development/aggregate-error-ponyfill/commit/ab7cde6ab78b520ecd4b7ba0c356c76aae4e919b))
+* **deps:** bump actions/github-script from 6.3.0 to 6.3.3 ([#19](https://github.com/flex-development/aggregate-error-ponyfill/issues/19)) ([7342ac4](https://github.com/flex-development/aggregate-error-ponyfill/commit/7342ac4b5a875c8402226138f4864a1c1995a7ba))
+* **deps:** bump actions/setup-node from 3.4.1 to 3.5.1 ([#18](https://github.com/flex-development/aggregate-error-ponyfill/issues/18)) ([8848b85](https://github.com/flex-development/aggregate-error-ponyfill/commit/8848b851f9b89d431a2c05ecc88f4a06286f4ed4))
+* **deps:** Bump crazy-max/ghaction-import-gpg from 5.1.0 to 5.2.0 ([#20](https://github.com/flex-development/aggregate-error-ponyfill/issues/20)) ([c89d660](https://github.com/flex-development/aggregate-error-ponyfill/commit/c89d660810ef977bc93704afaccfb8b3d04c47bc))
+* **deps:** Bump dependabot/fetch-metadata from 1.3.4 to 1.3.5 ([#21](https://github.com/flex-development/aggregate-error-ponyfill/issues/21)) ([5db5d52](https://github.com/flex-development/aggregate-error-ponyfill/commit/5db5d52eefd51b10f988db8da6849aed6076fbe0))
+* **deps:** bump octokit/graphql-action from 2.2.22 to 2.2.23 ([#16](https://github.com/flex-development/aggregate-error-ponyfill/issues/16)) ([d5ef350](https://github.com/flex-development/aggregate-error-ponyfill/commit/d5ef350e16176ed8ca590cd63c14124e6eff7b4d))
+
+
+### :house_with_garden: Housekeeping
+
+* update project architecture ([9730408](https://github.com/flex-development/aggregate-error-ponyfill/commit/9730408cdcc8b65a576604ed131011bc0ed7dc7a))
+
+
+### :zap: Refactors
+
+* remove `native` module ([1bfa22a](https://github.com/flex-development/aggregate-error-ponyfill/commit/1bfa22aeed91ed263fe39258090b67ff981036e7))
+
 ## [2.0.1](https://github.com/flex-development/aggregate-error-ponyfill/compare/2.0.0...2.0.1) (2022-10-02)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/aggregate-error-ponyfill",
   "description": "ES Proposal spec-compliant ponyfill for AggregateError",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "keywords": [
     "aggregate-error",
     "ecmascript",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `3.0.0`
- added `CHANGELOG` entry for `3.0.0`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
  RUN  v0.25.2
      Coverage enabled with c8

 ✓ src/__tests__/ponyfill.spec.ts > unit:ponyfill > should create spec-compliant AggregateError
 ✓ src/__tests__/ponyfill.spec.ts > unit:ponyfill > should throw if aggregated errors are not iterable

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  15:25:40
   Duration  3.74s (transform 475ms, setup 266ms, collect 131ms, tests 6ms)

 % Coverage report from c8
-------------|---------|----------|---------|---------|-------------------
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------|---------|----------|---------|---------|-------------------
All files    |     100 |      100 |     100 |     100 |                   
 ponyfill.ts |     100 |      100 |     100 |     100 |                   
-------------|---------|----------|---------|---------|-------------------
```

### `yarn pack -o %s-%v.tgz`

```zsh
➤ YN0036: Calling the "prepack" lifecycle script
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT ℹ Building @flex-development/aggregate-error-ponyfill
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT ✔ Build succeeded for @flex-development/aggregate-error-ponyfill
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   dist (total size: 2.88 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.mjs.map (115 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.mjs (94 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.d.mts (111 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.mjs.map (686 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.mjs (592 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.d.mts (1.29 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   dist (total size: 4.51 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.cjs.map (210 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.cjs (682 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/index.d.cts (111 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.cjs.map (956 B)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.cjs (1.27 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT   └─ dist/ponyfill.d.cts (1.29 kB)
➤ YN0000: @flex-development/aggregate-error-ponyfill@workspace:. STDOUT Σ Total build size: 7.4 kB
➤ YN0000: CHANGELOG.md
➤ YN0000: LICENSE.md
➤ YN0000: README.md
➤ YN0000: changelog.config.cts
➤ YN0000: dist/index.cjs
➤ YN0000: dist/index.cjs.map
➤ YN0000: dist/index.d.cts
➤ YN0000: dist/index.d.mts
➤ YN0000: dist/index.mjs
➤ YN0000: dist/index.mjs.map
➤ YN0000: dist/ponyfill.cjs
➤ YN0000: dist/ponyfill.cjs.map
➤ YN0000: dist/ponyfill.d.cts
➤ YN0000: dist/ponyfill.d.mts
➤ YN0000: dist/ponyfill.mjs
➤ YN0000: dist/ponyfill.mjs.map
➤ YN0000: package.json
➤ YN0000: src/index.ts
➤ YN0000: src/ponyfill.ts
➤ YN0036: Calling the "postpack" lifecycle script
➤ YN0000: Package archive generated in ./@flex-development-aggregate-error-ponyfill-3.0.0.tgz
➤ YN0000: Done in 6s 801ms
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/aggregate-error-ponyfill/blob/main/CONTRIBUTING.md#pull-request-titles
